### PR TITLE
deps: bump litellm upper bound to 1.83.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
 ]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "litellm<=1.82.6",
+    "litellm>=1.73,<=1.83.14,!=1.82.7,!=1.82.8",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

- Raises litellm ceiling from `<=1.82.6` to `<=1.83.14`
- Explicitly excludes `1.82.7` and `1.82.8` (TeamPCP supply chain compromise)
- Adds `>=1.73` floor (minimum version tested by downstream consumers)

## Why

The `<=1.82.6` pin was set to avoid the supply chain attack in versions 1.82.7/1.82.8. Now that litellm has published safe versions through 1.83.14, downstream projects need access to bug fixes and new provider support in the 1.83.x series.

## Test plan

- [x] `pytest jupyter_ai_litellm/tests/` — 2/2 pass on litellm 1.83.14
- [x] Verified litellm internals (annotations, logging, callbacks) intact on 1.83.14
- [x] Downstream project (jupyter-ai-rovanaut) full test suite: 1624 passed on 1.83.14