### PR TITLE
Replaced `litellm` plumbing with `langchain-litellm` - requires version increase to 1.94

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         architecture: 'x64'
     - uses: actions/download-artifact@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyter_ai_litellm"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "A JupyterLab extension that provides LiteLLM model abstraction"
 classifiers = [
     "Framework :: Jupyter",
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -28,7 +27,7 @@ authors = [
 ]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "litellm>=1.83.14,<2",
+    "litellm>=1.94.1,<2",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
 ]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "litellm<=1.82.6",
+    "litellm>=1.83.14,<2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Refactored the codebase to use `ChatLiteLLM` from `langchain-litellm` (https://github.com/langchain-ai/langchain-litellm) in place of the vendored community wrappers.

-  **[jupyter-ai-litellm/pyproject.toml](jupyter-ai-litellm/pyproject.toml)** — relaxed the `litellm<=1.82.6` pin to `litellm>=1.94.1,<2` so it can co-resolve with `langchain-litellm`'s requirement. Also requires `python>=3.10`. 

- **build.yml**: requires `python>=3.10`. 

See also this related PR: https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/pull/101
